### PR TITLE
Remove personal site link from nav

### DIFF
--- a/index.html
+++ b/index.html
@@ -103,11 +103,6 @@
                 >linkedin</a
               >
             </li>
-            <li>
-              <a href="https://ryan-workman.com/" target="_blank" rel="noopener"
-                >personal site</a
-              >
-            </li>
           </ul>
         </section>
       </article>


### PR DESCRIPTION
# Problem

The nav included a link to ryan-workman.com, which is a separate personal site. Having two personal sites linked from the same page creates confusion about which is canonical.

# Solution

Removed the personal site list item from the nav. The remaining links (GitHub, LinkedIn, etc.) are sufficient for directing visitors to relevant profiles.