### PR TITLE
Fix broken link to Pokémon TCG Catalog in side-project post

### DIFF
--- a/_posts/side-projects/2026-05-24-pokemon-card-scanner-in-one-night.md
+++ b/_posts/side-projects/2026-05-24-pokemon-card-scanner-in-one-night.md
@@ -15,7 +15,7 @@ snap a photo, and get a current price on the rarer ones. No standing there
 flipping through TCGPlayer one card at a time while a line of buyers waits on
 me.
 
-They say necessity is the mother of invention... thus my [Pokémon TCG Catalog](https://pokemontcg.workman.tech) was born.
+They say necessity is the mother of invention... thus my [Pokémon TCG Catalog](https://github.com/WorkmanTech/pokemon-tcg-inventory) was born.
 
 ## a side project, run like a real project
 

--- a/side-projects/2026-05-24-pokemon-card-scanner-in-one-night.html
+++ b/side-projects/2026-05-24-pokemon-card-scanner-in-one-night.html
@@ -129,7 +129,7 @@
           <p>
             They say necessity is the mother of invention… thus my
             <a
-              href="https://pokemontcg.workman.tech"
+              href="https://github.com/WorkmanTech/pokemon-tcg-inventory"
               target="_blank"
               rel="noopener"
               >Pokémon TCG Catalog</a


### PR DESCRIPTION
# Problem

The Pokémon TCG Catalog link in the side-project blog post pointed to a subdomain that no longer resolves, leaving readers with a dead link.

# Solution

Updated the inline link to point to the canonical GitHub repository at WorkmanTech/pokemon-tcg-inventory. This is the authoritative source for the project and will remain stable regardless of any hosting changes to the subdomain.